### PR TITLE
Regex simplifications and fixes for OSX

### DIFF
--- a/aws/profile-manager.zsh
+++ b/aws/profile-manager.zsh
@@ -358,7 +358,7 @@ __aws-profile-get-secret-key() {
 
 __aws-profile-get-region() {
     __aws-profile-get-section "$1" \
-        | sed -n 's/^ *region *= *\([^ ]\+\) *$/\1/p'
+        | sed -nE 's/^ *region *= *([^ ]+) *$/\1/p'
 }
 
 __aws-profile-get-source-profile() {


### PR DESCRIPTION
Add -E to sed calls and remove escapes, like in the example.